### PR TITLE
Added cancel offer functionality

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -130,8 +130,8 @@ h3 {
 
 a.nav-link.btn.btn-flat {
   color: #16B756;
-  margin: 10px 10px;
-  padding: 8px 4px;
+  margin: 22px 14px;
+  padding: 0;
   border-radius: 50px;
   background: white;
   transition: background 0.3s ease;

--- a/app/controllers/pick_ups_controller.rb
+++ b/app/controllers/pick_ups_controller.rb
@@ -29,7 +29,7 @@ class PickUpsController < ApplicationController
   # end
   # def new; end
   # def create; end
-  before_action :set_pick_up, only: [:show]
+  before_action :set_pick_up, only: %i[show destroy]
 
   def index
     @pick_ups = policy_scope(PickUp)
@@ -63,13 +63,15 @@ class PickUpsController < ApplicationController
     # we would pass the user_id and also all the packages for a given user id
     # if @package.user_id == current_user.id
     # @record.user == @user
-    @packages = Package.all
-    @pick_ups = @packages.select do
-      @record.user == @user
-    end
+    authorize @pick_up
+    # @packages = Package.all
+    # @pick_ups = @packages.select do |package|
+      # @record.user == @user
+      # package.user_id == current_user.id
+    # end
     # if @record.user == @user
     # end
-    @pick_ups
+    # @pick_ups
   end
 
   # def new
@@ -94,6 +96,15 @@ class PickUpsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def destroy
+    authorize @pick_up
+    @pick_up.destroy
+    @package = Package.find(@pick_up.package_id)
+    @package.update_attribute(:picked_up, false)
+    # redirect_to pick_ups_url, notice: 'Pick up was successfully cancelled.'
+    redirect_to pick_ups_url, notice: 'Pick up was successfully cancelled.'
   end
 
   private

--- a/app/policies/pick_up_policy.rb
+++ b/app/policies/pick_up_policy.rb
@@ -30,5 +30,6 @@ class PickUpPolicy < ApplicationPolicy
 
   def allowed_to_destroy?
     @record.user == @user
+    # pick_up.user_id == current_user.id
   end
 end

--- a/app/views/pick_ups/index.html.erb
+++ b/app/views/pick_ups/index.html.erb
@@ -17,6 +17,10 @@
         <p><%= package.content %></p>
       <strong>Package's Picked Up</strong>
         <p><%= package.picked_up %></p>
+        <!--when I click on the button, I'll call the destroy path(@package)--->
+      <p>
+          <%= link_to 'Cancell Pick Up', user_pick_up_path({user_id: pick_up.user_id, id: pick_up.id}), method: :delete, data: { confirm: 'Are you sure?' } %>
+      </p>
       <% end %>
   <% end %>
 <% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -12,19 +12,19 @@
       <ul class="navbar-nav me-auto">
         <% if user_signed_in? %>
           <li class="nav-item active">
-            <%= link_to "Home", root_path, class: "nav-link btn btn-flat" %>
+            <%= link_to "Recycler mode", root_path, class: "nav-link btn btn-flat" %>
           </li>
-          <li class="nav-item">
+          <li class="nav-item active">
+          <% @pick_ups = PickUp.all %>
+              <% if @pick_ups.find{|pick_up| pick_up.user_id == current_user.id} %>
+                <%= link_to "My Pickups", pick_ups_path, class: "nav-link btn btn-flat" %>
+              <% end %>
           </li>
           <li class="nav-item dropdown">
             <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class:"avatar-large dropdown-toggle", alt:"avatar-large", id: "navbarDropdown", data: { bs_toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
             <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
               <%= link_to "All Packages", packages_path, class: "dropdown-item" %>
-              <% @pick_ups = PickUp.all %>
-              <% if @pick_ups.find{|pick_up| pick_up.user_id == current_user.id} %>
-                <%= link_to "My Pickups", pick_ups_path, class: "dropdown-item" %>
-              <% end %>
-              <% @packages = Package.all %>
+              <!--<% @packages = Package.all %>-->
               <%= link_to "Confirmed Pickups", list_my_picked_up_packages_packages_path, class: "dropdown-item" %>
               <!--<%= link_to "Another action", "#", class: "dropdown-item" %>-->
               <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,8 @@ Rails.application.routes.draw do
     resources :pick_ups
   end
 
+  resources :packages do
+    resources :pick_ups
+  end
+
 end


### PR DESCRIPTION
Added cancel offer functionality using the destroy pick_up action and also setting the package picked_up attribute back to false so it appears again to be picked up on the packages page.